### PR TITLE
Fix TTY inversion, ANSI reset, logs dir creation, and tput cross-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,178 @@
-# Lucid Logger
-Custom logger package made with Python
+# LucidLogger
+
+A Python library for standardized terminal logging with ANSI color support, progress bars, and timed rotating file output.
+
+---
+
+## Features
+
+- Colored log output per level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+- Custom log levels with configurable colors
+- Inline progress/loading bars that coexist with log output
+- Auto-resizing progress bars based on terminal width
+- Cross-platform (Windows CMD, PowerShell, Bash)
+- Timed rotating file handler with dated filenames
+- File logs strip ANSI — clean output for log aggregators
+
+---
+
+## Installation
+
+```bash
+pip install lucid-logger
+```
+
+---
+
+## Quick Start
+
+```python
+from lucid_logger import LucidLogger, LucidLoadingBar
+
+logger = LucidLogger(name="app", log_lowest_level=10, colored_logs=True)
+logger.basic_config()
+
+logger.info("Server started")
+logger.warning("High memory usage")
+logger.error("Failed to connect")
+```
+
+### With a Progress Bar
+
+```python
+from lucid_logger import LucidLogger, LucidLoadingBar
+
+logger = LucidLogger(name="app", log_lowest_level=10, colored_logs=True)
+logger.basic_config()
+
+items = list(range(50))
+bar = LucidLoadingBar(name="import")
+bar.init_bar(iterable=items, prefix="Importing")
+logger.add_loading_bar(bar)
+
+for item in items:
+    # do work...
+    bar.progress_bar()
+    logger.info(f"Processing item {item}")
+
+bar.finish_loading()
+logger.info("Import complete")
+```
+
+---
+
+## API Reference
+
+### `LucidLogger`
+
+Extends `logging.Logger`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `name` | `str` | Logger name |
+| `log_lowest_level` | `int` | Minimum log level (e.g. `10` = DEBUG) |
+| `colored_logs` | `bool` | Enable ANSI color output |
+
+**Methods:**
+
+| Method | Description |
+|---|---|
+| `basic_config()` | Attach default stream and file handlers |
+| `add_loading_bar(bar)` | Register a `LucidLoadingBar` with the stream handler |
+| `get_loading_bar(name)` | Retrieve a registered bar by name |
+| `add_logging_level(level_name, level_num, color)` | Register a custom log level with a color |
+
+---
+
+### `LucidLoadingBar`
+
+A terminal progress bar that renders inline with log output.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | — | Unique identifier |
+| `iterable` | `iterable` | `None` | Collection to iterate over |
+| `prefix` | `str` | `'Loading...'` | Label shown before the bar |
+| `suffix` | `str` | `''` | Label shown after the bar |
+| `colored_logs` | `bool` | `True` | Enable ANSI color |
+| `fill` | `str` | `█` | Fill character |
+| `decimals` | `int` | `1` | Decimal places on the percent |
+| `length` | `int` | `100` | Bar width in characters |
+
+**Methods:**
+
+| Method | Description |
+|---|---|
+| `init_bar(iterable, prefix, total)` | Start the bar, auto-sizes to terminal width |
+| `progress_bar()` | Advance progress by one step |
+| `finish_loading()` | Mark the bar complete and clear it |
+| `get_bar()` | Return the current formatted bar string |
+
+---
+
+### `LucidStreamFormatter`
+
+Custom `logging.Formatter` that injects ANSI color codes per log level.
+
+Levels below `detailed_view_threshold` omit the filename/line number from the output to keep routine logs terse. Warnings and above include the source location.
+
+---
+
+### `LucidTimedRotatingFileHandler`
+
+Extends `TimedRotatingFileHandler`. Rotates at midnight and names files by date (`YYYY-MM-DD.log`).
+
+| Parameter | Default | Description |
+|---|---|---|
+| `directory` | `'./logs/'` | Output directory |
+| `when` | `'midnight'` | Rotation schedule |
+| `file_extension` | `'log'` | File extension |
+
+---
+
+## Color Reference
+
+Built-in named colors available for custom levels and bar segments:
+
+| Name | Hex |
+|---|---|
+| `grey` | `#C8C8C8` |
+| `white` | `#FFFFFF` |
+| `red` | `#FF0000` |
+| `yellow` | `#FFFF00` |
+| `green` | `#009600` |
+| `lime` | `#00FF00` |
+| `cyan` | `#00FFFF` |
+| `blue` | `#0000FF` |
+| `purple` | `#000096` |
+
+---
+
+## Custom Log Levels
+
+```python
+logger.add_logging_level("TRACE", 5, cyan)
+logger.trace("Entering request handler")
+```
+
+---
+
+## Log Output Format
+
+Stream (colored):
+```
+[MM/DD/YYYY HH:MM:SS][LEVEL] message
+[MM/DD/YYYY HH:MM:SS][WARNING][filename.py:42] message
+```
+
+File (plain):
+```
+[MM/DD/YYYY HH:MM:SS][INFO] message
+[MM/DD/YYYY HH:MM:SS][ERROR][filename.py:42] message
+```
+
+---
+
+## License
+
+MIT

--- a/src/lucid_logger/__init__.py
+++ b/src/lucid_logger/__init__.py
@@ -1,46 +1,33 @@
 from logging.handlers import TimedRotatingFileHandler
 from os import environ
-import sys
+import os
+import shutil
 import logging
-import subprocess
 from datetime import datetime
 
-isATty = sys.stdout.isatty()
-time_format = "$TIME_COLOR[%(asctime)s]$RESET[$LEVEL_COLOR%(levelname)s$RESET]$FILE$LINE $MESSAGE_COLOR%(message)s$RESET"
+RESET = "\033[0m"
 
-
-# def get_color_escape_string(color_name):
-
-
-grey = "\033[38;2;200;200;200m" if not isATty else '\033[48m'
-white = "\033[38;2;255;255;255m" if not isATty else '\033[48m'
-red = "\033[38;2;255;0;0m" if not isATty else '\033[48m'
-yellow = "\033[38;2;255;255;0m" if not isATty else '\033[48m'
-green = "\033[38;2;0;150;0m" if not isATty else '\033[48m'
-lime = "\033[38;2;0;255;0m" if not isATty else '\033[48m'
-cyan = "\033[38;2;0;255;255m" if not isATty else '\033[48m'
-blue = "\033[38;2;0;0;255m" if not isATty else '\033[48m'
-purple = "\033[38;2;0;0;150m" if not isATty else '\033[48m'
+grey = "\033[38;2;200;200;200m"
+white = "\033[38;2;255;255;255m"
+red = "\033[38;2;255;0;0m"
+yellow = "\033[38;2;255;255;0m"
+green = "\033[38;2;0;150;0m"
+lime = "\033[38;2;0;255;0m"
+cyan = "\033[38;2;0;255;255m"
+blue = "\033[38;2;0;0;255m"
+purple = "\033[38;2;0;0;150m"
 
 COLORS = {
-    "grey": "\033[38;2;200;200;200m",
-    "white": "\033[38;2;255;255;255m",
-    "red": "\033[38;2;255;0;0m",
-    "yellow": "\033[38;2;255;255;0m",
-    "green": "\033[38;2;0;150;0m",
-    "lime": "\033[38;2;0;255;0m",
-    "cyan": "\033[38;2;0;255;255m",
-    "blue": "\033[38;2;0;0;255m",
-    "purple": "\033[38;2;0;0;150m"
+    "grey": grey,
+    "white": white,
+    "red": red,
+    "yellow": yellow,
+    "green": green,
+    "lime": lime,
+    "cyan": cyan,
+    "blue": blue,
+    "purple": purple,
 }
-
-class Formats:
-    #  "$TIME_COLOR[%(asctime)s]$RESET[$LEVEL_COLOR%(levelname)s$RESET]$FILE$LINE $MESSAGE_COLOR%(message)s$RESET"
-    def __init__(self):
-        self.isATty = sys.stdout.isatty()
-
-        self.time_string_format = "[$TIME_COLOR%(asctime)s$RESET]"
-        self.level_string_format = "[$LEVEL_COLOR%(levelname)s$RESET]"
 
 
 class LucidLogger(logging.Logger):
@@ -140,7 +127,7 @@ class LucidLoadingBar:
 
     def format_bar(self, bar, percent):
         formatted_bar = self.bar_format\
-            .replace('$RESET', grey) \
+            .replace('$RESET', RESET) \
             .replace('$PREFIX_COLOR', self.prefix_color if self.prefix_color and self.colored_logs else '') \
             .replace('$PREFIX', self.prefix) \
             .replace('$BAR_COLOR', self.bar_color if self.bar_color and self.colored_logs else '') \
@@ -151,12 +138,7 @@ class LucidLoadingBar:
         return formatted_bar
 
     def init_bar(self, iterable=None, prefix="Loading...", total=None):
-        try:
-            tput = subprocess.Popen(['tput', 'cols'], stdout=subprocess.PIPE)
-            terminal_length = int(tput.communicate()[0].strip())
-        except FileNotFoundError:
-            terminal_length = 100
-
+        terminal_length = shutil.get_terminal_size(fallback=(100, 24)).columns
         self.is_loading = True
         self.total = len(iterable) if iterable else total
         self.length = (terminal_length - len(self.prefix) - 10)
@@ -181,7 +163,7 @@ class LucidStreamFormatter(logging.Formatter):
         self.time_color = grey
         self.message_color = grey
         self.datefmt = datefmt
-        self.colored_logs = colored_logs if not isATty else False
+        self.colored_logs = colored_logs
         self.detailed_view_threshold = detailed_view_threshold
         self.log_format = log_format
 
@@ -200,7 +182,7 @@ class LucidStreamFormatter(logging.Formatter):
         return ''
 
     def get_formatted_string(self, level_no):
-        formatted_string = self.log_format.replace("$RESET", grey)\
+        formatted_string = self.log_format.replace("$RESET", RESET)\
             .replace("$FILE", "" if level_no <= self.detailed_view_threshold else "[%(filename)s:")\
             .replace("$LINE", "" if level_no <= self.detailed_view_threshold else "%(lineno)d]")\
 
@@ -257,6 +239,7 @@ class LucidTimedRotatingFileHandler(TimedRotatingFileHandler):
         self.when = when
         self.interval = interval
         self.file_extension = file_extension
+        os.makedirs(directory, exist_ok=True)
         filename = f"{self.directory}{self.generateFileName()}.{self.file_extension}"
         TimedRotatingFileHandler.__init__(self, filename=filename, when=when, interval=interval)
 


### PR DESCRIPTION
## Summary
- Removes the inverted `isATty` logic that was silently disabling colors in real terminals
- Replaces `grey`-as-reset with a proper `RESET = "\033[0m"` constant used throughout
- Adds `os.makedirs(exist_ok=True)` in `LucidTimedRotatingFileHandler` so `./logs/` is created automatically on first run
- Replaces the `tput cols` subprocess with `shutil.get_terminal_size()` for cross-platform terminal width detection
- Removes dead `Formats` class and unused `subprocess`/`sys` imports
- Embellishes README with features list, quick start, full API reference, color table, and log format examples

Closes #7

## Test plan
- [ ] Run `python -c "from lucid_logger import LucidLogger; l = LucidLogger('test', 10, True); l.basic_config(); l.info('hello')"` — colored output should appear in the terminal
- [ ] Verify `./logs/YYYY-MM-DD.log` is created automatically without pre-creating the directory
- [ ] Confirm no `tput` subprocess errors on Windows