### PR TITLE
Add LucidSpinner for indeterminate progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,239 @@
-# Lucid Logger
-Custom logger package made with Python
+# LucidLogger
+
+A Python library for standardized terminal logging with ANSI color support, progress bars, spinners, and timed rotating file output.
+
+---
+
+## Features
+
+- Colored log output per level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+- Custom log levels with configurable colors
+- Inline progress/loading bars that coexist with log output
+- Indeterminate spinner for operations with unknown duration
+- Auto-resizing progress bars based on terminal width
+- Cross-platform (Windows CMD, PowerShell, Bash)
+- Timed rotating file handler with dated filenames
+- File logs strip ANSI — clean output for log aggregators
+
+---
+
+## Installation
+
+```bash
+pip install lucid-logger
+```
+
+---
+
+## Quick Start
+
+```python
+from lucid_logger import LucidLogger, LucidLoadingBar
+
+logger = LucidLogger(name="app", log_lowest_level=10, colored_logs=True)
+logger.basic_config()
+
+logger.info("Server started")
+logger.warning("High memory usage")
+logger.error("Failed to connect")
+```
+
+### With a Progress Bar (manual)
+
+```python
+from lucid_logger import LucidLogger, LucidLoadingBar
+
+logger = LucidLogger(name="app", log_lowest_level=10, colored_logs=True)
+logger.basic_config()
+
+items = list(range(50))
+bar = LucidLoadingBar(name="import")
+bar.init_bar(iterable=items, prefix="Importing")
+logger.add_loading_bar(bar)
+
+for item in items:
+    bar.progress_bar()
+    logger.info(f"Processing item {item}")
+
+bar.finish_loading()
+```
+
+### With a Progress Bar (wrap)
+
+```python
+bar = LucidLoadingBar(name="import")
+logger.add_loading_bar(bar)
+
+for item in bar.wrap(items, prefix="Importing"):
+    process(item)
+    logger.info(f"Processed {item}")
+```
+
+### With a Spinner
+
+```python
+from lucid_logger import LucidLogger, LucidSpinner
+
+logger = LucidLogger(name="app", log_lowest_level=10, colored_logs=True)
+logger.basic_config()
+
+spinner = LucidSpinner(name="fetch", prefix="Fetching data")
+logger.add_spinner(spinner)
+
+with spinner:
+    result = requests.get(url)
+
+logger.info("Fetch complete")
+```
+
+Or without a context manager:
+
+```python
+spinner.start()
+result = requests.get(url)
+spinner.stop()
+```
+
+---
+
+## API Reference
+
+### `LucidLogger`
+
+Extends `logging.Logger`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `name` | `str` | Logger name |
+| `log_lowest_level` | `int` | Minimum log level (e.g. `10` = DEBUG) |
+| `colored_logs` | `bool` | Enable ANSI color output |
+
+**Methods:**
+
+| Method | Description |
+|---|---|
+| `basic_config()` | Attach default stream and file handlers |
+| `add_loading_bar(bar)` | Register a `LucidLoadingBar` with the stream handler |
+| `get_loading_bar(name)` | Retrieve a registered bar by name |
+| `add_spinner(spinner)` | Register a `LucidSpinner` with the stream handler |
+| `add_logging_level(level_name, level_num, color)` | Register a custom log level with a color |
+
+---
+
+### `LucidLoadingBar`
+
+A terminal progress bar that renders inline with log output.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | — | Unique identifier |
+| `iterable` | `iterable` | `None` | Collection to iterate over |
+| `prefix` | `str` | `'Loading...'` | Label shown before the bar |
+| `suffix` | `str` | `''` | Label shown after the bar |
+| `colored_logs` | `bool` | `True` | Enable ANSI color |
+| `fill` | `str` | `█` | Fill character |
+| `decimals` | `int` | `1` | Decimal places on the percent |
+| `length` | `int` | `100` | Bar width in characters |
+
+**Methods:**
+
+| Method | Description |
+|---|---|
+| `init_bar(iterable, prefix, total)` | Start the bar, auto-sizes to terminal width |
+| `wrap(iterable, prefix)` | Iterate over `iterable` while auto-advancing the bar |
+| `progress_bar()` | Advance progress by one step |
+| `finish_loading()` | Mark the bar complete and clear it |
+| `get_bar()` | Return the current formatted bar string |
+
+---
+
+### `LucidSpinner`
+
+An indeterminate progress indicator that animates in place on a background thread. Log output from `LucidLogger` will pause the spinner frame, write the log line, then let the spinner resume — no interleaving.
+
+Uses Unicode braille frames (`⠋ ⠙ ⠹ …`) where supported, falls back to ASCII (`| / - \`).
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | — | Unique identifier |
+| `prefix` | `str` | `''` | Label shown before the spinner frame |
+| `colored_logs` | `bool` | `True` | Enable ANSI color |
+| `color` | `str` | `grey` | ANSI escape string for the spinner color |
+| `interval` | `float` | `0.1` | Seconds between frame advances |
+
+**Methods:**
+
+| Method | Description |
+|---|---|
+| `start()` | Begin animation on a daemon thread |
+| `stop()` | Stop animation, clear the line, join the thread |
+| `__enter__` / `__exit__` | Use as a context manager |
+
+---
+
+### `LucidStreamFormatter`
+
+Custom `logging.Formatter` that injects ANSI color codes per log level.
+
+Levels below `detailed_view_threshold` omit the filename/line number from the output to keep routine logs terse. Warnings and above include the source location.
+
+---
+
+### `LucidTimedRotatingFileHandler`
+
+Extends `TimedRotatingFileHandler`. Rotates at midnight and names files by date (`YYYY-MM-DD.log`). Creates the log directory automatically if it does not exist.
+
+| Parameter | Default | Description |
+|---|---|---|
+| `directory` | `'./logs/'` | Output directory |
+| `when` | `'midnight'` | Rotation schedule |
+| `file_extension` | `'log'` | File extension |
+
+---
+
+## Color Reference
+
+Built-in named colors available for custom levels and bar/spinner segments:
+
+| Name | Hex |
+|---|---|
+| `grey` | `#C8C8C8` |
+| `white` | `#FFFFFF` |
+| `red` | `#FF0000` |
+| `yellow` | `#FFFF00` |
+| `green` | `#009600` |
+| `lime` | `#00FF00` |
+| `cyan` | `#00FFFF` |
+| `blue` | `#0000FF` |
+| `purple` | `#000096` |
+
+---
+
+## Custom Log Levels
+
+```python
+logger.add_logging_level("TRACE", 5, cyan)
+logger.trace("Entering request handler")
+```
+
+---
+
+## Log Output Format
+
+Stream (colored):
+```
+[MM/DD/YYYY HH:MM:SS][LEVEL] message
+[MM/DD/YYYY HH:MM:SS][WARNING][filename.py:42] message
+```
+
+File (plain):
+```
+[MM/DD/YYYY HH:MM:SS][INFO] message
+[MM/DD/YYYY HH:MM:SS][ERROR][filename.py:42] message
+```
+
+---
+
+## License
+
+MIT

--- a/src/lucid_logger/__init__.py
+++ b/src/lucid_logger/__init__.py
@@ -3,7 +3,10 @@ from os import environ
 import sys
 import logging
 import subprocess
+import threading
 from datetime import datetime
+
+RESET = "\033[0m"
 
 isATty = sys.stdout.isatty()
 time_format = "$TIME_COLOR[%(asctime)s]$RESET[$LEVEL_COLOR%(levelname)s$RESET]$FILE$LINE $MESSAGE_COLOR%(message)s$RESET"
@@ -60,6 +63,9 @@ class LucidLogger(logging.Logger):
 
     def get_loading_bar(self, name):
         return self.stream_handler.loading_bars[name]
+
+    def add_spinner(self, spinner):
+        self.stream_handler.add_spinner(spinner)
 
     def add_logging_level(self, level_name, level_num, color, method_name=None):
         if not method_name:
@@ -173,6 +179,74 @@ class LucidLoadingBar:
         self.progress += 1
 
 
+class LucidSpinner:
+    """Indeterminate progress indicator that animates in place on a background thread."""
+
+    BRAILLE_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+    ASCII_FRAMES = ['|', '/', '-', '\\']
+
+    def __init__(self, name, prefix='', colored_logs=True, color=None, interval=0.1):
+        self.name = name
+        self.prefix = prefix
+        self.colored_logs = colored_logs
+        self.color = color if color is not None else grey
+        self.interval = interval
+        self.is_spinning = False
+        self._frame_index = 0
+        self._thread = None
+        self._stop_event = threading.Event()
+        self._write_lock = None  # injected by LucidStreamHandler
+        self._stream = None      # injected by LucidStreamHandler
+
+        try:
+            '⠋'.encode(sys.stdout.encoding or 'utf-8')
+            self.frames = self.BRAILLE_FRAMES
+        except (UnicodeEncodeError, LookupError):
+            self.frames = self.ASCII_FRAMES
+
+    def get_frame(self):
+        frame = self.frames[self._frame_index % len(self.frames)]
+        color = self.color if self.colored_logs else ''
+        reset = RESET if self.colored_logs else ''
+        return f"{color}{self.prefix} {frame}{reset}"
+
+    def get_clear_frame(self):
+        return ' ' * (len(self.prefix) + 2)
+
+    def _animate(self):
+        while not self._stop_event.is_set():
+            if self._stream is not None and self._write_lock is not None:
+                with self._write_lock:
+                    self._stream.write('\r' + self.get_frame())
+                    self._stream.flush()
+            self._frame_index += 1
+            self._stop_event.wait(self.interval)
+        if self._stream is not None and self._write_lock is not None:
+            with self._write_lock:
+                self._stream.write('\r' + self.get_clear_frame() + '\r')
+                self._stream.flush()
+
+    def start(self):
+        self.is_spinning = True
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._animate, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self):
+        self.is_spinning = False
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *_args):
+        self.stop()
+
+
 class LucidStreamFormatter(logging.Formatter):
     def __init__(
             self, datefmt="%m/%d/%Y %H:%M:%S", colored_logs=True, detailed_view_threshold=20,
@@ -229,19 +303,31 @@ class LucidStreamHandler(logging.StreamHandler):
         logging.StreamHandler.__init__(self)
         self.return_carriage = '\r'
         self.loading_bars = {}
+        self.spinners = {}
+        self._write_lock = threading.Lock()
 
     def get_stream_formatter(self):
         return self.formatter
 
+    def add_spinner(self, spinner):
+        spinner._write_lock = self._write_lock
+        spinner._stream = self.stream
+        self.spinners[spinner.name] = spinner
+
     def emit(self, record):
-        for loading_bar in self.loading_bars:
-            if self.loading_bars[loading_bar].is_loading:
-                self.stream.write(self.return_carriage + self.loading_bars[loading_bar].get_clear_bar() + self.return_carriage)
-        message = self.format(record)
-        self.stream.write(self.return_carriage + message + self.terminator)
-        for loading_bar in self.loading_bars:
-            if self.loading_bars[loading_bar]:
-                self.stream.write(self.return_carriage + self.loading_bars[loading_bar].get_bar() + self.return_carriage)
+        with self._write_lock:
+            for bar in self.loading_bars.values():
+                if bar.is_loading:
+                    self.stream.write(self.return_carriage + bar.get_clear_bar() + self.return_carriage)
+            for spinner in self.spinners.values():
+                if spinner.is_spinning:
+                    self.stream.write(self.return_carriage + spinner.get_clear_frame() + self.return_carriage)
+            message = self.format(record)
+            self.stream.write(self.return_carriage + message + self.terminator)
+            for bar in self.loading_bars.values():
+                if bar.is_loading:
+                    self.stream.write(self.return_carriage + bar.get_bar() + self.return_carriage)
+            self.stream.flush()
 
 
 class LucidFileFormatter(logging.Formatter):


### PR DESCRIPTION
## Summary
- Adds `LucidSpinner` — animates braille or ASCII frames on a daemon thread while coexisting cleanly with log output
- `LucidStreamHandler` gains a `threading.Lock` and `spinners` dict; `emit` acquires the lock so log lines and spinner animation never interleave
- `LucidLogger.add_spinner(spinner)` registers the spinner with the stream handler, injecting the shared lock and stream reference
- Supports both direct `start()`/`stop()` and context manager usage
- Unicode braille frames with ASCII fallback for terminals that can't encode them

Closes #9

## Test plan
- [ ] Spinner animates between log calls without interleaving
- [ ] `with spinner:` clears the line cleanly after the block
- [ ] Log messages appear on their own line while spinner is active
- [ ] ASCII fallback renders when Unicode is unavailable