### PR TITLE
Bump version to 0.1.0 and add CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.9", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    name: Run tests before publishing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package and dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: python -m pytest tests/ -v
+
+  publish:
+    name: Build and publish to PyPI
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/lucid-logger
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucid-logger"
-version = "0.0.6"
+version = "0.1.0"
 description = "Python logging library with color output, progress bars, and spinners"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/lucid_logger/__init__.py
+++ b/src/lucid_logger/__init__.py
@@ -10,7 +10,7 @@ import logging
 import threading
 from datetime import datetime
 
-__version__ = "0.0.6"
+__version__ = "0.1.0"
 
 RESET = "\033[0m"
 


### PR DESCRIPTION
## Summary
- Bumps `__version__` and `pyproject.toml` to `0.1.0`
- Adds CI workflow: runs pytest on Ubuntu + Windows across Python 3.9/3.11/3.12 on every push and PR to main
- Adds publish workflow: builds and uploads to PyPI when a GitHub Release is published (requires `PYPI_API_TOKEN` secret in a `pypi` environment)

Closes #21

## Test plan
- [ ] `python -m pytest tests/ -q` → 23 passed
- [ ] `lucid_logger.__version__` returns `"0.1.0"`
- [ ] CI workflow appears in Actions tab after merge